### PR TITLE
Add WaveWatch3 class

### DIFF
--- a/news/2.misc
+++ b/news/2.misc
@@ -1,0 +1,4 @@
+Set up continuous integration using GitHub actions. This includes tests to
+ensure that the code is styled according to *black*, is free of lint, and
+passes all unit tests.
+

--- a/news/3.feature
+++ b/news/3.feature
@@ -1,0 +1,5 @@
+Added ``WaveWatch3`` class, which is the main access point for users of this package.
+This class downloads WaveWatch III data files (if not already cached) and provides a
+view of the data as an xarray Dataset. Users can then advance through the data
+month-by-month, downloading additional data as necessary.
+

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,0 +1,49 @@
+import pytest
+
+from wavewatch3 import ChoiceError, WaveWatch3URL
+
+
+@pytest.mark.parametrize("region", WaveWatch3URL.REGIONS)
+@pytest.mark.parametrize("quantity", WaveWatch3URL.QUANTITIES)
+def test_url(region, quantity):
+    url = WaveWatch3URL("2010-05-22", quantity, region=region)
+    assert url.year == 2010
+    assert url.month == 5
+    assert url.quantity == quantity
+    assert url.region == region
+    assert url.filename == f"multi_1.{region}.{quantity}.201005.grb2"
+
+
+@pytest.mark.parametrize("quantity", WaveWatch3URL.QUANTITIES)
+def test_url_default_region(quantity):
+    url = WaveWatch3URL("2010-05-22", quantity)
+    assert url.region == "glo_30m"
+
+
+def test_url_str():
+    url = WaveWatch3URL("2010-05-22", "wind")
+    assert str(url).startswith(WaveWatch3URL.SCHEME)
+
+
+def test_url_repr():
+    url = WaveWatch3URL("2010-05-22", "tp")
+    assert eval(repr(url)) == url
+
+
+def test_url_quantity_setter():
+    url = WaveWatch3URL("2010-05-22", "tp")
+    url.quantity = "dp"
+    assert url.quantity == "dp"
+    assert url == WaveWatch3URL("2010-05-22", "dp")
+
+    with pytest.raises(ChoiceError):
+        url.quantity = "foo"
+
+
+def test_url_region_setter():
+    url = WaveWatch3URL("2010-05-22", "tp")
+    url.region = "ak_4m"
+    assert url == WaveWatch3URL("2010-05-22", "tp", region="ak_4m")
+
+    with pytest.raises(ChoiceError):
+        url.region = "bar"

--- a/tests/test_wavewatch3.py
+++ b/tests/test_wavewatch3.py
@@ -1,0 +1,49 @@
+from wavewatch3 import WaveWatch3
+
+
+def test_wavewatch3():
+    ww3 = WaveWatch3("2010-05-22")
+    assert ww3.date == "2010-05-22"
+    assert ww3.year == 2010
+    assert ww3.month == 5
+    assert ww3.region == "glo_30m"
+
+
+def test_wavewatch3_inc():
+    ww3 = WaveWatch3("2010-03-14")
+    assert ww3.date == "2010-03-14"
+
+    ww3.inc()
+    assert ww3.date == "2010-04-14"
+    assert (ww3.month, ww3.year) == (4, 2010)
+
+    ww3.inc(12)
+    assert ww3.date == "2011-04-14"
+    assert (ww3.month, ww3.year) == (4, 2011)
+
+    ww3.inc(-2)
+    assert ww3.date == "2011-02-14"
+    assert (ww3.month, ww3.year) == (2, 2011)
+
+
+def test_wavewatch3_date():
+    ww3 = WaveWatch3("2001-01-01")
+    assert ww3.date == "2001-01-01"
+
+    ww3.date = "1973-03-14"
+    assert ww3.date == "1973-03-14"
+    assert (ww3.month, ww3.year) == (3, 1973)
+
+
+def test_repr():
+    ww3 = WaveWatch3("2008-12-31")
+    assert eval(repr(ww3)) == ww3
+
+
+def test_equivalent():
+    assert WaveWatch3("2008-12-31") == WaveWatch3("2008-12-31", region="glo_30m")
+    assert WaveWatch3("2008-12-31", region="ak_4m") != WaveWatch3(
+        "2008-12-31", region="glo_30m"
+    )
+    assert WaveWatch3("2009-12-31") != WaveWatch3("2008-12-31")
+    assert WaveWatch3("2009-12-31") == WaveWatch3("2009-12-01")

--- a/wavewatch3/__init__.py
+++ b/wavewatch3/__init__.py
@@ -1,13 +1,16 @@
 from ._version import __version__
 from .bmi import BmiWaveWatch3
 from .downloader import WaveWatch3Downloader
-from .url import WaveWatch3URL
 from .errors import ChoiceError, WaveWatch3Error
+from .url import WaveWatch3URL
+from .wavewatch3 import WaveWatch3
+
 
 __all__ = [
     "__version__",
     "BmiWaveWatch3",
     "ChoiceError",
+    "WaveWatch3",
     "WaveWatch3Downloader",
     "WaveWatch3Error",
     "WaveWatch3URL",

--- a/wavewatch3/__init__.py
+++ b/wavewatch3/__init__.py
@@ -1,6 +1,14 @@
 from ._version import __version__
 from .bmi import BmiWaveWatch3
 from .downloader import WaveWatch3Downloader
+from .url import WaveWatch3URL
+from .errors import ChoiceError, WaveWatch3Error
 
-
-__all__ = ["__version__", "BmiWaveWatch3", "WaveWatch3Downloader"]
+__all__ = [
+    "__version__",
+    "BmiWaveWatch3",
+    "ChoiceError",
+    "WaveWatch3Downloader",
+    "WaveWatch3Error",
+    "WaveWatch3URL",
+]

--- a/wavewatch3/cli.py
+++ b/wavewatch3/cli.py
@@ -7,7 +7,8 @@ from multiprocessing import Pool, RLock
 
 import click
 from tqdm.auto import tqdm
-from .downloader import WaveWatch3Downloader, WaveWatch3URL
+from .downloader import WaveWatch3Downloader
+from .url import WaveWatch3URL
 
 
 out = partial(click.secho, bold=True, file=sys.stderr)

--- a/wavewatch3/downloader.py
+++ b/wavewatch3/downloader.py
@@ -1,5 +1,6 @@
 import pathlib
 import urllib
+import urllib.request
 import datetime
 
 import xarray as xr
@@ -23,84 +24,26 @@ class WaveWatch3Downloader:
     }
     QUANTITIES = {"wind", "hs", "tp", "dp"}
 
-    def __init__(self, url, lazy_load=False, clobber=False):
+    def __init__(self, url, force=False):
         self._url = url
-        self._clobber = clobber
+        self._force = force
         self._filepath = None
-        self._data = None
-
-        if not lazy_load:
-            self.data
-
-    @classmethod
-    def from_params(cls, date=None, region="glo_30m", quantity="hs", **kwds):
-        return cls(
-            WaveWatch3Downloader.data_url(date=date, region=region, quantity=quantity),
-            **kwds,
-        )
-
-    @staticmethod
-    def data_url(date=None, region="glo_30m", quantity="hs"):
-        if region not in WaveWatch3Downloader.REGIONS:
-            raise ValueError(f"{region!r}: unknown region")
-        if quantity not in WaveWatch3Downloader.QUANTITIES:
-            raise ValueError(f"{quantity!r}: unknown quantity")
-
-        date = datetime.today() if date is None else datetime.fromisoformat(date)
-
-        prefix = pathlib.PosixPath(f"{date.year}/{date.month:02d}")
-        prefix /= region if date.year < 2017 else "gribs"
-
-        path = str(
-            WaveWatch3Downloader.PREFIX
-            / prefix
-            / f"multi_1.{region}.{quantity}.{date.year}{date.month:02d}.grb2"
-        )
-
-        return urllib.parse.urlunparse(
-            [WaveWatch3Downloader.SCHEME, WaveWatch3Downloader.NETLOC, path, "", "", ""]
-        )
 
     @staticmethod
     def url_file_part(url):
         return pathlib.Path(urllib.parse.urlparse(url).path).name
 
     @staticmethod
-    def fetch(url, destination=None, clobber=True):
-        destination = pathlib.Path("." if destination is None else destination)
-        name = pathlib.Path(urllib.parse.urlparse(url).path).name
-
-        if destination.is_dir():
-            destination /= name
-
-        if destination.is_file() and not clobber:
-            raise ValueError(f"{destination}: file exists")
-
-        filepath, msg = urllib.request.urlretrieve(url, filename=destination)
-
-        return destination.absolute()
-
-    @staticmethod
-    def retreive(url, filename=None, reporthook=None):
+    def retreive(url, filename=None, reporthook=None, force=False):
         if filename is None:
             filename = WaveWatch3Downloader.url_file_part(url)
-        filepath, msg = urllib.request.urlretrieve(
-            url, reporthook=reporthook, data=None, filename=filename
-        )
-        return filepath
-
-    @staticmethod
-    def load(filepath):
-        return xr.load_dataset(filepath, engine="cfgrib")
-
-    @property
-    def data(self):
-        if self._data is None:
-            self._filepath = WaveWatch3Downloader.fetch(
-                self._url, clobber=self._clobber
+        if not pathlib.Path(filename).is_file() or force:
+            filepath, _ = urllib.request.urlretrieve(
+                url, reporthook=reporthook, data=None, filename=filename
             )
-            self._data = WaveWatch3Downloader.load(self._filepath)
-        return self._data
+        else:
+            filepath = filename
+        return pathlib.Path(filepath).absolute()
 
     @property
     def filepath(self):

--- a/wavewatch3/downloader.py
+++ b/wavewatch3/downloader.py
@@ -1,9 +1,6 @@
 import pathlib
 import urllib
 import urllib.request
-import datetime
-
-import xarray as xr
 
 
 class WaveWatch3Downloader:

--- a/wavewatch3/downloader.py
+++ b/wavewatch3/downloader.py
@@ -1,6 +1,6 @@
 import pathlib
 import urllib
-from datetime import datetime
+import datetime
 
 import xarray as xr
 

--- a/wavewatch3/errors.py
+++ b/wavewatch3/errors.py
@@ -1,0 +1,12 @@
+class WaveWatch3Error(Exception):
+    pass
+
+
+class ChoiceError(WaveWatch3Error):
+    def __init__(self, choice, choices):
+        self._choice = choice
+        self._choices = tuple(choices)
+
+    def __str__(self):
+        choices = ", ".join([repr(c) for c in self._choices])
+        return f"{self._choice!r}: invalid choice (not one of {choices})"

--- a/wavewatch3/url.py
+++ b/wavewatch3/url.py
@@ -77,9 +77,17 @@ class WaveWatch3URL:
     def year(self):
         return self._date.year
 
+    @year.setter
+    def year(self, year):
+        self._date = datetime.date(year, self.month, self._date.day)
+
     @property
     def month(self):
         return self._date.month
+
+    @month.setter
+    def month(self, month):
+        self._date = datetime.date(self.year, month, self._date.day)
 
     @property
     def filename(self):

--- a/wavewatch3/url.py
+++ b/wavewatch3/url.py
@@ -1,0 +1,86 @@
+import datetime
+import pathlib
+import urllib
+
+from .errors import ChoiceError
+
+
+class WaveWatch3URL:
+    SCHEME = "https"
+    NETLOC = "www.ncei.noaa.gov"
+    PREFIX = "/thredds-ocean/fileServer/ncep/nww3"
+
+    REGIONS = {
+        "glo_30m",
+        "ao_30m",
+        "at_10m",
+        "wc_10m",
+        "ep_10m",
+        "ak_10m",
+        "at_4m",
+        "wc_4m",
+        "ak_4m",
+    }
+    QUANTITIES = {"wind", "hs", "tp", "dp"}
+
+    def __init__(self, date, quantity, region="glo_30m"):
+        self._date = datetime.date.fromisoformat(date)
+        self._quantity = None
+        self._region = None
+
+        self.quantity = quantity
+        self.region = region
+
+    def __str__(self):
+        prefix = pathlib.PosixPath(f"{self.year}/{self.month:02d}")
+        prefix /= self.region if self.year < 2017 else "gribs"
+
+        return urllib.parse.urlunparse(
+            [
+                WaveWatch3URL.SCHEME,
+                WaveWatch3URL.NETLOC,
+                str(WaveWatch3URL.PREFIX / prefix / self.filename),
+                "",
+                "",
+                "",
+            ]
+        )
+
+    def __repr__(self):
+        date = self._date.isoformat()
+        return f"WaveWatch3URL({date!r}, {self.quantity!r}, region={self.region!r})"
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+    @property
+    def region(self):
+        return self._region
+
+    @region.setter
+    def region(self, region):
+        if region not in WaveWatch3URL.REGIONS:
+            raise ChoiceError(region, WaveWatch3URL.REGIONS)
+        self._region = region
+
+    @property
+    def quantity(self):
+        return self._quantity
+
+    @quantity.setter
+    def quantity(self, quantity):
+        if quantity not in WaveWatch3URL.QUANTITIES:
+            raise ChoiceError(quantity, WaveWatch3URL.QUANTITIES)
+        self._quantity = quantity
+
+    @property
+    def year(self):
+        return self._date.year
+
+    @property
+    def month(self):
+        return self._date.month
+
+    @property
+    def filename(self):
+        return f"multi_1.{self.region}.{self.quantity}.{self.year}{self.month:02d}.grb2"

--- a/wavewatch3/url.py
+++ b/wavewatch3/url.py
@@ -32,7 +32,7 @@ class WaveWatch3URL:
         self.region = region
 
     def __str__(self):
-        prefix = pathlib.PosixPath(f"{self.year}/{self.month:02d}")
+        prefix = pathlib.PurePosixPath(f"{self.year}", f"{self.month:02d}")
         prefix /= self.region if self.year < 2017 else "gribs"
 
         return urllib.parse.urlunparse(

--- a/wavewatch3/wavewatch3.py
+++ b/wavewatch3/wavewatch3.py
@@ -33,6 +33,10 @@ class WaveWatch3:
         return self._data
 
     @property
+    def region(self):
+        return self._urls[0].region
+
+    @property
     def date(self):
         return self._date.isoformat()
 
@@ -75,6 +79,13 @@ class WaveWatch3:
         date = self._urls[0]._date.isoformat()
         region = self._urls[0].region
         return f"WaveWatch3({date!r}, region={region!r})"
+
+    def __eq__(self, other):
+        return (
+            self.month == other.month
+            and self.year == other.year
+            and self.region == other.region
+        )
 
 
 @contextlib.contextmanager

--- a/wavewatch3/wavewatch3.py
+++ b/wavewatch3/wavewatch3.py
@@ -1,0 +1,90 @@
+import contextlib
+import datetime
+import os
+import pathlib
+from multiprocessing import Pool
+
+import xarray as xr
+from dateutil.relativedelta import relativedelta
+
+from .downloader import WaveWatch3Downloader
+from .url import WaveWatch3URL
+
+
+class WaveWatch3:
+    def __init__(self, date, region="glo_30m", cache="~/.wavewatch3/data", lazy=True):
+        self._cache = pathlib.Path(cache).expanduser()
+        self._lazy = lazy
+        self._data = None
+        self._date = None
+
+        self._urls = [
+            WaveWatch3URL(date, quantity=quantity, region=region)
+            for quantity in WaveWatch3URL.QUANTITIES
+        ]
+        self.date = date
+        if not lazy:
+            self._load_data()
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._load_data()
+        return self._data
+
+    @property
+    def date(self):
+        return self._date.isoformat()
+
+    @date.setter
+    def date(self, date):
+        new_date = datetime.date.fromisoformat(date)
+        if new_date != self._date:
+            self._date = new_date
+            for url in self._urls:
+                url.month = new_date.month
+                url.year = new_date.year
+            if not self._lazy:
+                self._load_data()
+
+    @property
+    def year(self):
+        return self._date.year
+
+    @property
+    def month(self):
+        return self._date.month
+
+    def inc(self, months=1):
+        self.date = (self._date + relativedelta(months=months)).isoformat()
+
+    def _load_data(self):
+        self._fetch_data()
+        self._data = xr.open_mfdataset(
+            [self._cache / url.filename for url in self._urls],
+            engine="cfgrib",
+            parallel=True,
+        )
+
+    def _fetch_data(self):
+        self._cache.mkdir(parents=True, exist_ok=True)
+        with as_cwd(self._cache):
+            Pool().map(WaveWatch3Downloader.retreive, [str(url) for url in self._urls])
+
+    def __repr__(self):
+        date = self._urls[0]._date.isoformat()
+        region = self._urls[0].region
+        return f"WaveWatch3({date!r}, region={region!r})"
+
+
+@contextlib.contextmanager
+def as_cwd(path):
+    """Change directory context.
+
+    Args:
+        path (str): Path-like object to a directory.
+    """
+    prev_cwd = pathlib.Path.cwd()
+    os.chdir(path)
+    yield prev_cwd
+    os.chdir(prev_cwd)


### PR DESCRIPTION
This pull request adds a `WaveWatch3` class, which is intended to be the main access point for users of this package.

An example usage might be something like the following,
```python
>>> from wavewatch3 import WaveWatch3
>>> ww3 = WaveWatch3("2008-03-14")
>>> ww3.data
<xarray.Dataset>
...
```
The `ww3.data` attribute downloads the WaveWatch III data files (if not already cached) and provides a view of the data as an *xarray* *Dataset*. A user can then advance through WaveWatch III data month-by-month using the `inc` method,
```python
>>> ww3 = WaveWatch3("2010-05-22")
>>> ww3.date
'2010-05-22'
>>> ww3.inc()
>>> ww3.date
'2010-06-22'
```
New data are downloaded and cached as necessary.

