### PR TITLE
Add subcommand to clean cache files

### DIFF
--- a/news/4.feature
+++ b/news/4.feature
@@ -1,0 +1,2 @@
+Added the ``ww3 clean`` subcommand that removes cached data files.
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_subcommand_help(subcommand):
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize("subcommand", ("url", "fetch", "clean"))
+@pytest.mark.parametrize("subcommand", ("url", "fetch"))
 def test_noop(subcommand):
     runner = CliRunner()
     result = runner.invoke(ww3, [subcommand])
@@ -42,5 +42,5 @@ def test_clean(tmpdir):
         result = runner.invoke(ww3, ["clean", "--cache-dir=.", "--dry-run"])
         assert data_file.is_file()
 
-        result = runner.invoke(ww3, ["clean", "--cache-dir=."])
+        result = runner.invoke(ww3, ["clean", "--cache-dir=.", "--yes"])
         assert not data_file.is_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 from click.testing import CliRunner
 
@@ -15,15 +17,30 @@ def test_command_line_interface():
     assert "version" in result.output
 
 
-@pytest.mark.parametrize("subcommand", ("url", "fetch"))
+@pytest.mark.parametrize("subcommand", ("url", "fetch", "clean"))
 def test_subcommand_help(subcommand):
     runner = CliRunner()
     result = runner.invoke(ww3, [subcommand, "--help"])
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize("subcommand", ("url", "fetch"))
+@pytest.mark.parametrize("subcommand", ("url", "fetch", "clean"))
 def test_noop(subcommand):
     runner = CliRunner()
     result = runner.invoke(ww3, [subcommand])
     assert result.exit_code == 0
+
+
+def test_clean(tmpdir):
+    runner = CliRunner()
+
+    with tmpdir.as_cwd():
+        data_file = pathlib.Path("multi_1.glo_30m.dp.201712.grb2")
+        data_file.touch()
+
+        assert data_file.is_file()
+        result = runner.invoke(ww3, ["clean", "--cache-dir=.", "--dry-run"])
+        assert data_file.is_file()
+
+        result = runner.invoke(ww3, ["clean", "--cache-dir=."])
+        assert not data_file.is_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,8 +39,8 @@ def test_clean(tmpdir):
         data_file.touch()
 
         assert data_file.is_file()
-        result = runner.invoke(ww3, ["clean", "--cache-dir=.", "--dry-run"])
+        runner.invoke(ww3, ["clean", "--cache-dir=.", "--dry-run"])
         assert data_file.is_file()
 
-        result = runner.invoke(ww3, ["clean", "--cache-dir=.", "--yes"])
+        runner.invoke(ww3, ["clean", "--cache-dir=.", "--yes"])
         assert not data_file.is_file()

--- a/wavewatch3/cli.py
+++ b/wavewatch3/cli.py
@@ -122,10 +122,10 @@ def clean(ctx, dry_run, cache_dir, yes):
         itertools.chain(cache_dir.glob(pattern), cache_dir.glob(pattern + ".*.idx"))
     )
 
-    if not silent:
-        total_bytes = 0
+    total_bytes = sum([cache_file.stat().st_size for cache_file in cache_files])
+
+    if not silent and not dry_run:
         for cache_file in cache_files:
-            total_bytes += cache_file.stat().st_size
             out(f"{cache_file}")
         out(f"Total size: {total_bytes // 2**20} MB")
 
@@ -139,6 +139,9 @@ def clean(ctx, dry_run, cache_dir, yes):
             out(f"rm {cache_file}")
         else:
             cache_file.unlink()
+
+    if not dry_run and (verbose and not silent):
+        out(f"Removed {len(cache_files)} files ({total_bytes} bytes)")
 
 
 def _retreive_urls(urls, disable=False, force=False):


### PR DESCRIPTION
This pull request adds the *clean* subcommand to `ww3` that remove cached data files.

The following removes all cached data files from the default location (`~/.wavewatch3/data`)
```bash
$ ww3 clean
```
A user can specify another location through the `--cache-dir` option.