### PR TITLE
Add additional data sources

### DIFF
--- a/news/6.feature
+++ b/news/6.feature
@@ -1,0 +1,3 @@
+Added additional WaveWatch III data sources from which users can fraw data
+from.
+

--- a/wavewatch3/downloader.py
+++ b/wavewatch3/downloader.py
@@ -4,23 +4,6 @@ import urllib.request
 
 
 class WaveWatch3Downloader:
-    SCHEME = "https"
-    NETLOC = "www.ncei.noaa.gov"
-    PREFIX = "/thredds-ocean/fileServer/ncep/nww3"
-
-    REGIONS = {
-        "glo_30m",
-        "ao_30m",
-        "at_10m",
-        "wc_10m",
-        "ep_10m",
-        "ak_10m",
-        "at_4m",
-        "wc_4m",
-        "ak_4m",
-    }
-    QUANTITIES = {"wind", "hs", "tp", "dp"}
-
     def __init__(self, url, force=False):
         self._url = url
         self._force = force


### PR DESCRIPTION
This pull request adds the ability for a user to specify a data source from which to fetch WaveWatch III data. Users can choose to get data from the following sources,
* https://www.ncei.noaa.gov/thredds-ocean/catalog/ncep/nww3/catalog.html
* https://polar.ncep.noaa.gov/waves/hindcasts/multi_1/
* https://polar.ncep.noaa.gov/waves/hindcasts/nww3/
