### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: TestPyPI
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+[ab][0-9]+'
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to TestPyPI
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      
+      - name: Install twine
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install twine
+          python --version
+          pip --version
+          twine --version
+        
+      - name: Create source distribution
+        run: |
+          python setup.py sdist --dist-dir wheelhouse
+        
+      - name: Upload source distribution
+        run: |
+          twine upload --skip-existing wheelhouse/*.tar.gz

--- a/news/10.misc
+++ b/news/10.misc
@@ -1,0 +1,5 @@
+Set up GitHub Action to create a source distribution and push it to
+*TestPyPI*. This action is only run if the version tag is a prerelease version
+(i.e. the version string ends with ``[ab][0-9]+``).
+
+

--- a/news/11.misc
+++ b/news/11.misc
@@ -1,0 +1,5 @@
+Set up GitHub Action to create a source distribution and push it to
+*PyPI*. This action is only run if the version tag is a release version
+(i.e. the version string doesn't end with ``[ab][0-9]+``).
+
+


### PR DESCRIPTION
This pull request adds a GitHub Action that pushes a source distribution to *PyPI* on version tags that **_don't_** end with `[ab][0-9]+`.